### PR TITLE
Only run e2e during PRs. No reason to run on main

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,9 +4,7 @@ name: E2E Tests CI
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
-  push:
-    branches: [ "main" ]
+  # Triggers the workflow on pull request events but only for the "main" branch
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
Only run e2e during PRs. No reason to run on main