### PR TITLE
Fix centering across app bars. Fixes #874

### DIFF
--- a/src/ConfigEditorPage.tsx
+++ b/src/ConfigEditorPage.tsx
@@ -211,8 +211,8 @@ class ConfigEditorPage extends React.Component<{
 
                 <AppBar>
                     <Grid container>
-                        <Grid item xs={5} marginTop="10px" sx={{ maxWidth: "220px" }}><IconButton onClick={this.handleBackClick} >{<ArrowBackIcon />}</IconButton></Grid>
-                        <Grid item xs={2} marginTop="5.75px" sx={{ maxWidth: "220px" }}>
+                        <Grid size={5} marginTop="10px" sx={{ maxWidth: "220px" }}><IconButton onClick={this.handleBackClick} >{<ArrowBackIcon />}</IconButton></Grid>
+                        <Grid size={2} marginTop="5.75px" sx={{ maxWidth: "220px" }}>
                             <Stack alignContent="center" sx={{ maxWidth: "220px" }}>
                                 <Button variant='inlineNavButton' onClick={() => {
                                     this.setState({
@@ -221,7 +221,7 @@ class ConfigEditorPage extends React.Component<{
                                 }} endIcon={<ArrowDropDownIcon />}>{this.getConfigName()}</Button>
                             </Stack>
                         </Grid>
-                        <Grid item xs={5}></Grid>
+                        <Grid size={5}></Grid>
                     </Grid>
                 </AppBar>
 

--- a/src/ConfigPicker.tsx
+++ b/src/ConfigPicker.tsx
@@ -125,7 +125,7 @@ class ConfigPicker extends React.Component<{
         return (
             <>
                 <Grid container>
-                    <Grid item xs={10}>
+                    <Grid size={10}>
                         <Item>
                         <FormControl fullWidth size='small'>
                             <InputLabel id="config-dropdown-label">Config</InputLabel>
@@ -145,7 +145,7 @@ class ConfigPicker extends React.Component<{
                         </Item>
 
                     </Grid>
-                    <Grid item xs={1}>
+                    <Grid size={1}>
                         <Item>
                         <IconButton onClick={this.editClicked}>
                             <EditIcon></EditIcon>
@@ -153,7 +153,7 @@ class ConfigPicker extends React.Component<{
 
                         </Item>
                     </Grid>
-                    <Grid item  xs={1}>
+                    <Grid size={1}>
                         <Item>
                         <IconButton onClick={this.addClicked}>
                             <AddIcon></AddIcon>

--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -204,7 +204,7 @@ class HomePage extends React.Component<{
       <>
         <AppBar>
           <Grid container>
-            <Grid item xs={4} marginTop="5.75px">
+            <Grid size={4} marginTop="5.75px">
               <Stack spacing={2} direction="row">
                 <Box></Box>
                 <Button aria-describedby="actionButton" variant='inlineNavButton'><img src={LogoMark} width="25px"></img></Button>
@@ -212,7 +212,7 @@ class HomePage extends React.Component<{
               </Stack>
             </Grid>
 
-            <Grid item xs={4} marginTop="5.75px">
+            <Grid size={4} marginTop="5.75px">
               <Stack alignContent="center">
                 <Box display="flex" justifyContent="center" alignItems="center" >
                   <Button variant='inlineNavButton' endIcon={<Home />}>Home</Button>
@@ -296,7 +296,7 @@ class HomePage extends React.Component<{
             <Box height={'24px'}></Box>
             <Grid container>
 
-              <Grid item>
+              <Grid>
                 <Button aria-describedby="orgSelecter" onClick={this.orgSelecterClicked} variant='inlineFilterButton' startIcon={<PersonOutlineOutlinedIcon fontSize="60" />} endIcon={<ArrowDropDownIcon />} justifyContent="space-between">{this.state.selectedOrg ? this.state.selectedOrg.name : "Personal"}</Button>
                 <Popover
                   id="orgSelecter"
@@ -325,7 +325,7 @@ class HomePage extends React.Component<{
                       <Button variant='inlineFilterButton' startIcon={<HistoryIcon fontSize="60" />} endIcon={<ArrowDropDownIcon />} justifyContent="space-between">Recent</Button>
                     </Grid>
                   */}
-                  <Grid item marginRight="14px">
+                  <Grid marginRight="14px">
                     <Button variant='inlineFilterButton' startIcon={<AccountTreeIcon fontSize="60" />} endIcon={<ArrowDropDownIcon />} justifyContent="space-between" onClick={this.projectTreePickerClicked}> {this.state.filterToTrees ? "Trees" : "Projects"}</Button>
 
                   </Grid>

--- a/src/NodePane.tsx
+++ b/src/NodePane.tsx
@@ -284,13 +284,13 @@ class NodePane extends React.Component<{
         if (relevantAttributes.includes(key)) {
           attributes.push(
             <Grid key={"container_" + key} container spacing={1}>
-              <Grid key={"item_" + key} item xs={9} >
+              <Grid key={"item_" + key} size={9} >
                 <TextField disabled={!readOnly} id={key} key={key}  sx={{
           marginBottom: '24px',
         }} label={key} onChange={this.handleAttributeChange} variant="outlined" size="small" value={this.getAttributeValue(value)} /> 
   
               </Grid>      
-              <Grid item xs={3}>
+              <Grid size={3}>
                 <IconButton disabled={!readOnly} onClick={() => {
                   this.deleteAttribute(key);
                 }}><DeleteIcon /></IconButton>
@@ -310,14 +310,14 @@ class NodePane extends React.Component<{
     return (
       <>
       <Grid container spacing={1}>
-        <Grid item xs={6}>
+        <Grid size={6}>
           <TextField label="Name" variant="outlined" size="small" id='newAttributeNameField' value={this.state.addAttributeName} onChange={(event) => {
             this.setState({
               addAttributeName: event.target.value
             })
           }} />
         </Grid>
-        <Grid item xs={6}>
+        <Grid size={6}>
           <TextField label="Value" variant="outlined" size="small" id='newAttributeValueField' value={this.state.addAttributeValue} onChange={(event) => {
             this.setState({
               addAttributeValue: event.target.value
@@ -325,10 +325,10 @@ class NodePane extends React.Component<{
           }} />
         </Grid>
         
-        <Grid item xs={12}>
+        <Grid size={12}>
           <Button disabled={this.state.addAttributeName === '' || this.state.addAttributeValue === ''} fullWidth={true} variant="addButton" startIcon={<AddIcon />} onClick={this.createAttribute}>Add Attribute</Button>
         </Grid>
-        <Grid item xs={2}> </Grid>
+        <Grid size={2}> </Grid>
 
       </Grid>
 

--- a/src/OrgList.tsx
+++ b/src/OrgList.tsx
@@ -105,7 +105,7 @@ class OrgList extends React.Component {
 
     return (
       <>
-      <Grid item xs={2}>
+      <Grid size={2}>
       
         <Stack display="flex-row" direction="row" justifyContent="" flexWrap="wrap">
 

--- a/src/OrgSettingsPage.tsx
+++ b/src/OrgSettingsPage.tsx
@@ -298,7 +298,7 @@ class OrgSettingsPage extends React.Component<{
 
               </Stack>
 
-              <Grid item xs={2}>
+              <Grid size={2}>
 
 
                 <Stack display="flex-row" direction="row" justifyContent="start" flexWrap="wrap">

--- a/src/PersonalTokenPage.tsx
+++ b/src/PersonalTokenPage.tsx
@@ -86,7 +86,7 @@ class PersonalTokenPage extends React.Component<{
       <>
         <AppBar>
           <Grid container>
-            <Grid item xs={4} marginTop="5.75px">
+            <Grid size={4} marginTop="5.75px">
               <Stack spacing={2} direction="row">
                 <Box></Box>
                 <Button aria-describedby="actionButton" variant='inlineNavButton'><img src={LogoMark} width="25px"></img></Button>
@@ -94,7 +94,7 @@ class PersonalTokenPage extends React.Component<{
               </Stack>
             </Grid>
 
-            <Grid item xs={4} marginTop="5.75px">
+            <Grid size={4} marginTop="5.75px">
               <Stack alignContent="center">
                 <Box display="flex" justifyContent="center" alignItems="center" >
                   <Button variant='inlineNavButton' endIcon={<Home />} onClick={() => {

--- a/src/ProjectTreeList.tsx
+++ b/src/ProjectTreeList.tsx
@@ -253,7 +253,7 @@ class ProjectTreeList extends React.Component<{
         }
 
         return (
-            <Grid item xs={2}>
+            <Grid size={2}>
                 <Typography variant="h1" display="block" margin="18px" padding="15px 15px 15px 0px">{this.props.org ? "Org" : "Personal"}{this.props.showTrees ? " trees" : " projects"}</Typography>
 
                 {sadTrees}

--- a/src/Projects.tsx
+++ b/src/Projects.tsx
@@ -144,7 +144,7 @@ async handleDeleteProject() {
       <>
         <AppBar>
           <Grid container>
-            <Grid item xs={4} marginTop="5.75px">
+            <Grid size={4} marginTop="5.75px">
               <Stack spacing={2} direction="row">
                 <Box></Box>
                 <Button aria-describedby="actionButton" onClick={this.handleActionPanelOpen} variant='inlineNavButton' ><img src={LogoMark} width="25px"></img></Button>
@@ -152,7 +152,7 @@ async handleDeleteProject() {
               </Stack>
             </Grid>
 
-            <Grid item xs={4} marginTop="5.75px">
+            <Grid size={4} marginTop="5.75px">
               <Stack alignContent="center">
                 <Box display="flex" justifyContent="center" alignItems="center" >
                   <Button variant='inlineNavButton' onClick={this.handleModalOpen} endIcon={<ArrowDropDownIcon />}>{this.state['projectName']}</Button>

--- a/src/ProjectsList.tsx
+++ b/src/ProjectsList.tsx
@@ -47,7 +47,7 @@ class ProjectsList extends React.Component<{
       // We need counts of the trees in each project
       const treeCountMap = {};
       for (const project of data['result']['projects']) {
-        const numTrees = await this.getNumTreesInProject(project.projectId );
+        const numTrees = await this.getNumTreesInProject(project.projectId);
         treeCountMap[project.projectId] = numTrees;
       }
 
@@ -75,7 +75,7 @@ class ProjectsList extends React.Component<{
     const rows: JSX.Element[] = [];
 
     for (const project of projects) {
-      
+
 
       if ((!this.props.org && !project.orgId) || this.props.org === project.orgId) {
         const path = "/projects?id=" + project.projectId;
@@ -92,7 +92,7 @@ class ProjectsList extends React.Component<{
               <CardContent><Stack direction="row" alignItems="center" gap={1}>
                 <Typography variant="h1" display="inline">
                   {project.name} •
-                </Typography> <Typography variant="body1" display="inline">{ this.state['treeCountMap'][project.projectId] } Tree{ this.state['treeCountMap'][project.projectId] > 1 ? 's' : '' }</Typography></Stack>
+                </Typography> <Typography variant="body1" display="inline">{this.state['treeCountMap'][project.projectId]} Tree{this.state['treeCountMap'][project.projectId] > 1 ? 's' : ''}</Typography></Stack>
 
                 {/*
                   <br></br>
@@ -118,46 +118,46 @@ class ProjectsList extends React.Component<{
     }
 
     return (
-      <Grid item xs={2}>
+      <Grid size={2}>
         <Typography variant="h1" display="block" margin="18px" padding="15px 15px 15px 0px">{this.props.org ? "Org Projects" : "Your Projects"}</Typography>
 
         <Grid container>
 
-          <Grid item>
-          <Button aria-describedby="orgSelecter" onClick={this.orgSelecter} variant='inlineFilterButton' startIcon={<PersonOutlineOutlinedIcon fontSize="60"/>} endIcon={<ArrowDropDownIcon /> } justifyContent="space-between">My Organization</Button>
-                <Popover
-                  id="orgSelecter"
-                  anchorReference="anchorPosition"
-                  anchorPosition={{ top: 50, left: 0 }}
-                  open={this.state.orgSelecterOpen}
-                  onClose={this.orgSelecterClose}
-                  anchorOrigin={{
-                    vertical: 'bottom',
-                    horizontal: 'center',
-                  }}
-                >
+          <Grid>
+            <Button aria-describedby="orgSelecter" onClick={this.orgSelecter} variant='inlineFilterButton' startIcon={<PersonOutlineOutlinedIcon fontSize="60" />} endIcon={<ArrowDropDownIcon />} justifyContent="space-between">My Organization</Button>
+            <Popover
+              id="orgSelecter"
+              anchorReference="anchorPosition"
+              anchorPosition={{ top: 50, left: 0 }}
+              open={this.state.orgSelecterOpen}
+              onClose={this.orgSelecterClose}
+              anchorOrigin={{
+                vertical: 'bottom',
+                horizontal: 'center',
+              }}
+            >
 
-                  <Stack>
-                    <List component="nav">
-                      <ListItem>
-                        <ListItemButton onClick={this.goBackToProjects}>
-                          <ListItemText primary="Back to Trees" />
-                        </ListItemButton>
-                      </ListItem>
-                    </List>
-                  </Stack>
+              <Stack>
+                <List component="nav">
+                  <ListItem>
+                    <ListItemButton onClick={this.goBackToProjects}>
+                      <ListItemText primary="Back to Trees" />
+                    </ListItemButton>
+                  </ListItem>
+                </List>
+              </Stack>
 
-                </Popover>
+            </Popover>
           </Grid>
           <Stack alignContent="right" direction="row" marginLeft="auto">
             <Box display="flex" justifyContent="right" alignItems="right" >
-            <Grid item>
-            <Button aria-describedby="orgSelecter" onClick={this.orgSelecter} variant='inlineFilterButton' startIcon={<HistoryIcon fontSize="60" />} endIcon={<ArrowDropDownIcon /> } justifyContent="space-between">Recent</Button>
-          </Grid>
-          <Grid item marginRight="14px">
-      <Button aria-describedby="orgSelecter" onClick={this.orgSelecter} variant='inlineFilterButton' startIcon={<AccountTreeIcon fontSize="60" />} endIcon={<ArrowDropDownIcon /> } justifyContent="space-between">Trees</Button>
-      </Grid>
-          </Box>
+              <Grid>
+                <Button aria-describedby="orgSelecter" onClick={this.orgSelecter} variant='inlineFilterButton' startIcon={<HistoryIcon fontSize="60" />} endIcon={<ArrowDropDownIcon />} justifyContent="space-between">Recent</Button>
+              </Grid>
+              <Grid marginRight="14px">
+                <Button aria-describedby="orgSelecter" onClick={this.orgSelecter} variant='inlineFilterButton' startIcon={<AccountTreeIcon fontSize="60" />} endIcon={<ArrowDropDownIcon />} justifyContent="space-between">Trees</Button>
+              </Grid>
+            </Box>
           </Stack>
         </Grid>
 

--- a/src/SettingsAppBar.tsx
+++ b/src/SettingsAppBar.tsx
@@ -40,7 +40,7 @@ class SettingsAppBar extends React.Component<{
       <>
         <AppBar>
           <Grid container>
-            <Grid item xs={4} marginTop="5.75px">
+            <Grid size={4} marginTop="5.75px">
               <Stack spacing={2} direction="row">
                 <Box></Box>
                 <Button aria-describedby="actionButton" onClick={() => {
@@ -49,7 +49,7 @@ class SettingsAppBar extends React.Component<{
               </Stack>
             </Grid>
 
-            <Grid item xs={4} marginTop="5.75px">
+            <Grid size={4} marginTop="5.75px">
               <Stack alignContent="center">
                 <Box display="flex" justifyContent="center" alignItems="center" >
                   <Button variant='inlineNavButton' endIcon={<Home />} onClick={() => {

--- a/src/TreePicker.tsx
+++ b/src/TreePicker.tsx
@@ -76,11 +76,11 @@ class TreePicker extends React.Component<{
               {this.generateOptions()}
               <Typography>From Community</Typography>
               <Grid container>
-                <Grid item xs={8}>
+                <Grid size={8}>
                   <TextField id="customNodeId" label="Node ID" size="small"></TextField>
                 </Grid>
-                <Grid item xs={1}></Grid>
-                <Grid item xs={3}>
+                <Grid size={1}></Grid>
+                <Grid size={3}>
                   <Button onClick={() => {
                     const nodeId = document.getElementById("customNodeId").value;
                     if (nodeId && nodeId !== '') {

--- a/src/TreeViewPage.tsx
+++ b/src/TreeViewPage.tsx
@@ -946,7 +946,7 @@ class TreeViewPage extends React.Component<{
 
         <AppBar>
           <Grid container>
-            <Grid item xs={5} marginTop="5.75px">
+            <Grid size={5} marginTop="5.75px">
               <Stack spacing={2} direction="row">
                 <Box></Box>
 
@@ -1048,12 +1048,12 @@ class TreeViewPage extends React.Component<{
               </Stack>
             </Grid>
 
-            <Grid item xs={2} marginTop="5.75px" sx={{ maxWidth: "220px" }}>
+            <Grid size={2} marginTop="5.75px" sx={{ maxWidth: "220px" }}>
               <Stack alignContent="center" sx={{ maxWidth: "220px" }}>
                 <Button variant='inlineNavButton' onClick={this.handleOpen} endIcon={<ArrowDropDownIcon />}>{this.getTreeName()}</Button>
               </Stack>
             </Grid>
-            <Grid item xs={5} marginTop="10px">
+            <Grid size={5} marginTop="10px">
 
               <Stack spacing={2} direction="row" justifyContent="flex-end" >
 

--- a/src/TreesList.tsx
+++ b/src/TreesList.tsx
@@ -96,25 +96,6 @@ class TreesList extends React.Component<{
               <Typography variant="h1" display="inline">
                 {tree.title} •
               </Typography> <Typography variant="body1" display="inline">{subtree} subtree {subtree == 1 ? '' : 's'}</Typography></Stack>
-
-              {/*
-                <br></br>
-              
-              <Stack direction="row" alignItems="bottom" gap={1}>
-                <PersonIcon fontSize="small"></PersonIcon>
-                <Typography variant="body2" gutterBottom>
-                  [Personal]
-                </Typography>
-              </Stack>
-
-              <Stack direction="row" alignItems="bottom" gap={1}>
-                <CalendarMonthIcon fontSize="small"></CalendarMonthIcon>
-                <Typography variant="body2">
-                  [DateModified]
-                </Typography>
-              </Stack>
-
-              */}
             </CardContent>
           </CardActionArea>
         </Card>)
@@ -123,7 +104,7 @@ class TreesList extends React.Component<{
 
     return (
 
-      <Grid item xs={2}><Stack direction="row" padding="15px" alignItems="Center"><IconButton onClick={this.handleBackClick} >{<ArrowBackIcon />}</IconButton><Typography variant="h1" display="inline" margin="18px" >{this.props.projectName}</Typography></Stack>
+      <Grid size={2}><Stack direction="row" padding="15px" alignItems="Center"><IconButton onClick={this.handleBackClick} >{<ArrowBackIcon />}</IconButton><Typography variant="h1" display="inline" margin="18px" >{this.props.projectName}</Typography></Stack>
         <Stack display="flex-row" direction="row" justifyContent="" flexWrap="wrap">
           {rows}
         </Stack>


### PR DESCRIPTION
Fix centering across app bars. This seems to have occured due to Mui changes in how you handle Mui items (`size` attributes expected vs. `xs`). This fixes #874